### PR TITLE
Add missing metadata for the packages

### DIFF
--- a/data/packages/Tplyr.yaml
+++ b/data/packages/Tplyr.yaml
@@ -6,4 +6,3 @@ hex: https://raw.githubusercontent.com/atorus-research/Tplyr/master/man/figures/
 task: tlg
 details: To simplify the data manipulation necessary to create clinical reports
 hexwall: TRUE
-

--- a/data/packages/admiral.yaml
+++ b/data/packages/admiral.yaml
@@ -1,10 +1,9 @@
 name: admiral
 repo: pharmaverse/admiral
 repo_source: github.com
-docs: https://pharmaverse.github.io/admiral/cran-release/
+docs: https://pharmaverse.github.io/admiral/
 hex: https://github.com/insightsengineering/hex-stickers/raw/main/PNG/admiral.png
 task: ADaM
 details: (ADaM In R Asset Library) - Modular framework to generate ADaM via R functions relying on community contributions
 splash: include
 hexwall: TRUE
-

--- a/data/packages/admiralonco.yaml
+++ b/data/packages/admiralonco.yaml
@@ -6,4 +6,3 @@ hex: https://raw.githubusercontent.com/pharmaverse/admiralonco/main/man/figures/
 task: ADaM
 details: Oncology
 hexwall: FALSE
-

--- a/data/packages/admiralophtha.yaml
+++ b/data/packages/admiralophtha.yaml
@@ -6,4 +6,3 @@ hex: https://raw.githubusercontent.com/pharmaverse/admiralophtha/main/man/figure
 task: ADaM
 details: Ophthalmology
 hexwall: FALSE
-

--- a/data/packages/admiralvaccine.yaml
+++ b/data/packages/admiralvaccine.yaml
@@ -1,9 +1,8 @@
 name: admiralvaccine
 repo: pharmaverse/admiralvaccine
 repo_source: github.com
-docs:
+docs: https://pharmaverse.github.io/admiralvaccine/
 hex: https://raw.githubusercontent.com/pharmaverse/admiralvaccine/main/man/figures/logo.png
 task: ADaM
 details: Vaccines RELEASE EXPECTED ~2023
 hexwall: FALSE
-

--- a/data/packages/chevron.yaml
+++ b/data/packages/chevron.yaml
@@ -1,9 +1,8 @@
 name: chevron
-repo: 
-repo_source: 
-docs: 
+repo: insightsengineering/chevron
+repo_source: github.com
+docs: https://insightsengineering.github.io/chevron
 hex: https://github.com/insightsengineering/hex-stickers/raw/main/PNG/chevron.png
 task: tlg
-details: Holds TLG template standards to feed into other tabulation packages OPEN SOURCE RELEASE EXPECTED ~END-2023 Contact Lena Wang (wangx216@gene.com)
+details: Holds TLG template standards to create standard outputs for clinical trials reporting with limited parameterisation.
 hexwall: FALSE
-

--- a/data/packages/covtracer.yaml
+++ b/data/packages/covtracer.yaml
@@ -9,4 +9,3 @@ details: >
   linking tests to code & code to documentation. 
   This package is used to provide the tracebility matrix for CICD based validation.
 hexwall: TRUE
-

--- a/data/packages/datacutr.yaml
+++ b/data/packages/datacutr.yaml
@@ -6,4 +6,3 @@ hex: https://github.com/pharmaverse/datacutr/raw/main/man/figures/logo.png
 task: sdtm
 details: Applying a datacut to SDTM
 hexwall: TRUE
-

--- a/data/packages/envsetup.yaml
+++ b/data/packages/envsetup.yaml
@@ -1,10 +1,9 @@
 name: envsetup
 repo: pharmaverse/envsetup
 repo_source: github.com
-docs: https://pharmaverse.github.io/envsetup/main/index.html
+docs: https://pharmaverse.github.io/envsetup/
 hex: https://pharmaverse.github.io/envsetup/main/logo.png
 task: utilities
 details: Support the setup of an R environment
 splash: include
 hexwall: TRUE
-

--- a/data/packages/falcon.yaml
+++ b/data/packages/falcon.yaml
@@ -4,5 +4,5 @@ repo_source: github.com
 docs: https://pharmaverse.github.io/falcon/
 hex: https://github.com/pharmaverse/falcon/raw/main/quarto/assets/images/falcon.png
 task: tlg
-details: Implementation of FDA Safety Tables and Figures OPEN SOURCE COLLABORATION IN PROGRESS Contact Pawel Rucki (pawel.rucki@roche.com) to get involved
+details: Implementation of table-generating functions to implement standard FDA Safety Tables according to the guidelines.
 hexwall: FALSE

--- a/data/packages/ggsurvfit.yaml
+++ b/data/packages/ggsurvfit.yaml
@@ -2,7 +2,7 @@ name: ggsurvfit
 repo: pharmaverse/ggsurvfit
 repo_source: github.com
 docs: http://www.danieldsjoberg.com/ggsurvfit/
-hex:  https://github.com/pharmaverse/ggsurvfit/raw/main/man/figures/logo.png
+hex: https://github.com/pharmaverse/ggsurvfit/raw/main/man/figures/logo.png
 task: tlg
 details: Eases the creation of time-to-event (aka survival) summary figures
 hexwall: TRUE

--- a/data/packages/logrx.yaml
+++ b/data/packages/logrx.yaml
@@ -7,4 +7,3 @@ task: utilities
 details: Generates an execution log to support reproducibility and traceability of an R script
 splash: include
 hexwall: TRUE
-

--- a/data/packages/metacore.yaml
+++ b/data/packages/metacore.yaml
@@ -4,7 +4,6 @@ repo_source: github.com
 docs: https://atorus-research.github.io/metacore/
 hex: https://github.com/atorus-research/metacore/raw/main/man/figures/metacore.PNG
 task: metadata
-details: Provides an interface to read in various metadata sources and store in a standardized object 
+details: Provides an interface to read in various metadata sources and store in a standardized object
 splash: include
 hexwall: TRUE
-

--- a/data/packages/metatools.yaml
+++ b/data/packages/metatools.yaml
@@ -6,4 +6,3 @@ hex: https://github.com/pharmaverse/metatools/raw/main/man/figures/metatools.png
 task: metadata
 details: Enables the use of metacore objects to build, enhance or check datasets using metadata - including removing/adding supplemental qualifiers from/to the parent SDTM domain
 hexwall: TRUE
-

--- a/data/packages/pharmaRTF.yaml
+++ b/data/packages/pharmaRTF.yaml
@@ -6,4 +6,3 @@ hex: https://user-images.githubusercontent.com/31387567/151176597-7707d789-c47c-
 task: tlg
 details: Enhanced RTF wrapper written in R for use with existing R tables packages such as huxtable or GT
 hexwall: TRUE
-

--- a/data/packages/pkglite.yaml
+++ b/data/packages/pkglite.yaml
@@ -7,4 +7,3 @@ task: esub
 details: To represent and exchange R package source code as text files, e.g. readable code
 splash: include
 hexwall: TRUE
-

--- a/data/packages/riskmetric.yaml
+++ b/data/packages/riskmetric.yaml
@@ -6,4 +6,3 @@ hex: https://raw.githubusercontent.com/pharmaR/riskmetric/master/man/figures/hex
 task: validation
 details: Framework to quantify R package risk by assessing a number of meaningful metrics.
 hexwall: TRUE
-

--- a/data/packages/roak.yaml
+++ b/data/packages/roak.yaml
@@ -1,7 +1,7 @@
 name: roak
-repo: 
-repo_source: 
-docs: 
+repo:
+repo_source:
+docs:
 hex: https://user-images.githubusercontent.com/82581364/133067114-65f89b9c-be77-4a85-8d78-bd6229c24921.png
 task: sdtm
 details: SDTM mapping algorithms via R functions OPEN SOURCE RELEASE EXPECTED IN 2024 Contact Ram Ganapathy (ganapar1@gene.com)

--- a/data/packages/rtables.yaml
+++ b/data/packages/rtables.yaml
@@ -7,4 +7,3 @@ task: tlg
 details: A framework for declaring complex multi-level tabulations and then applying them to data
 splash: include
 hexwall: TRUE
-

--- a/data/packages/sdtmchecks.yaml
+++ b/data/packages/sdtmchecks.yaml
@@ -6,4 +6,3 @@ hex: https://raw.githubusercontent.com/pharmaverse/sdtmchecks/main/man/figures/l
 task: sdtm
 details: Contains data check functions to identify SDTM issues that are generalizable, actionable, and meaningful for analysis
 hexwall: TRUE
-

--- a/data/packages/teal.yaml
+++ b/data/packages/teal.yaml
@@ -6,4 +6,3 @@ hex: https://github.com/insightsengineering/hex-stickers/raw/main/PNG/teal.png
 task: tlg
 details: Framework developed that leverages the R Shiny package to scale development of our shiny apps
 hexwall: TRUE
-

--- a/data/packages/tern.yaml
+++ b/data/packages/tern.yaml
@@ -6,4 +6,3 @@ hex: https://github.com/insightsengineering/hex-stickers/raw/main/PNG/tern.png
 task: tlg
 details: Layers analytics from descriptive summaries to more complex statistics on top of the foundational table layouts, analytic and content controls
 hexwall: TRUE
-

--- a/data/packages/tfrmt.yaml
+++ b/data/packages/tfrmt.yaml
@@ -6,4 +6,3 @@ hex: https://raw.githubusercontent.com/GSK-Biostatistics/tfrmt/main/man/figures/
 task: tlg
 details: A language for defining display-related metadata to automate the transformation from an Analysis Results Dataset (ARD) to a table
 hexwall: TRUE
-

--- a/data/packages/thevalidatoR.yaml
+++ b/data/packages/thevalidatoR.yaml
@@ -4,9 +4,8 @@ repo_source: github.com
 docs: https://github.com/marketplace/actions/r-package-validation-report
 hex: https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/thevalidatoR.png
 task: validation
-details: > 
-    A GitHub action on the GitHub Marketplace to provide standardised build reports for 
-    validation. An alternative approach to valtools that relies on the normal 
-    R framework for validation.
+details: >
+  A GitHub action on the GitHub Marketplace to provide standardised build reports for 
+  validation. An alternative approach to valtools that relies on the normal 
+  R framework for validation.
 hexwall: FALSE
-

--- a/data/packages/tidyCDISC.yaml
+++ b/data/packages/tidyCDISC.yaml
@@ -6,4 +6,3 @@ hex: https://raw.githubusercontent.com/Biogen-Inc/tidyCDISC/master/man/figures/h
 task: tlg
 details: A shiny app to easily create custom tables and figures from ADaM-ish data sets
 hexwall: TRUE
-

--- a/data/packages/tidytlg.yaml
+++ b/data/packages/tidytlg.yaml
@@ -6,4 +6,3 @@ hex: https://user-images.githubusercontent.com/61123199/152377149-83d7aea2-b78b-
 task: tlg
 details: Generate table, listings, and graphs (TLG) using the Tidyverse
 hexwall: TRUE
-

--- a/data/packages/valtools.yaml
+++ b/data/packages/valtools.yaml
@@ -6,4 +6,3 @@ hex: https://github.com/phuse-org/valtools/raw/main/man/figures/logo.png
 task: validation
 details: Validation framework for R packages that allows you to bolt in additional validation documentation.
 hexwall: TRUE
-

--- a/data/packages/xportr.yaml
+++ b/data/packages/xportr.yaml
@@ -6,4 +6,3 @@ hex: https://github.com/atorus-research/xportr/raw/main/man/figures/logo.png
 task: esub
 details: Serves as a single tool to create SAS transport files and perform pharma specific dataset level validation checks
 hexwall: TRUE
-


### PR DESCRIPTION
Some links were missing from the package metadata and this cleans them.

### Changes
- Formats all the metadata `yaml` files.
- Standardise or add the docs link, for example admiral or admiralvaccine
- Adds missing repo link to chevron
- Update details for chevron and falcon as they are open-sourced now

People to notify: 
@pawelru please check the details update in `chevron` and `falcon`