### PR TITLE
chore: Update download-artifact action

### DIFF
--- a/.github/workflows/update-universe.yml.disabled
+++ b/.github/workflows/update-universe.yml.disabled
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - name: Download packages aartifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: packages
       


### PR DESCRIPTION
As it'll be deprecated starting December 2024

Also this is the only place in this org where v3 used, even though it is a disabled workflow.