### PR TITLE
trying to fix hexwall script action fail in site build

### DIFF
--- a/data/packages/test.assessr.yaml
+++ b/data/packages/test.assessr.yaml
@@ -5,4 +5,4 @@ docs: https://sanofi-public.github.io/test.assessr/
 hex: https://raw.githubusercontent.com/sanofi-public/test.assessr/main/man/figures/test_assessr.png
 task: validation
 details: Tools for assessing test reliability of R packages with standard or non-standard testing frameworks
-hexwall: yes
+hexwall: no


### PR DESCRIPTION
hexwall script is failing in the site build - could be down to the format of the newly added test.assessr logo so will try without this included


# Pull Request
<!--- Pull requests to prod are ONLY accepted from develop branch -->
<!--- Please confirm you have checked this builds correctly on develop branch -->

- [ ] This is a PR into production (main), and I am doing it from develop
- [ ] If from develop, I have checked the code is working on the UAT site https://pharmaverse-staging-test.netlify.app/

# Description
<!--- What's new in this pull request? -->


## Metadata

Please reference any related issues here (using `#issuenumber`): 
People to notify: @website-maintainers
