### PR TITLE
Pavel/get commits failure

### DIFF
--- a/scripts/ppnetwork.R
+++ b/scripts/ppnetwork.R
@@ -31,10 +31,36 @@ packages <- map(yaml_files, \(x){
 git_stats <- create_gitstats() |>
     set_github_host(repos = packages$repo, token = Sys.getenv("GITHUB_PAT"))
 
-repo_all_commits <- git_stats |>
-  get_commits(
-    since = Sys.Date() - 365 * 10
-  )
+failed_repos <- c()
+
+# try to fetch 10-year history of commits for each repo
+repo_all_commits <- purrr::imap(packages$repo, function(repo, idx) {
+  cat(idx, "/", length(packages$repo), "-", repo, "\n")
+  tryCatch({
+    create_gitstats() |>
+      set_github_host(repos = repo, token = Sys.getenv("GITHUB_PAT")) |>
+      get_commits(since = Sys.Date() - 365 * 10)
+  }, error = function(e) {
+    warning("Failed to fetch commits for: ", repo)
+    failed_repos <<- c(failed_repos, repo)
+    data.frame()
+  })
+})
+
+# attempt to fetch 1-year history of commits for failed repos
+failed_repo_all_commits <- purrr::imap(failed_repos, function(repo, idx) {
+  cat(idx, "/", length(failed_repos), "-", repo, "\n")
+  tryCatch({
+    create_gitstats() |>
+      set_github_host(repos = repo, token = Sys.getenv("GITHUB_PAT")) |>
+      get_commits(since = Sys.Date() - 365 * 1)
+  }, error = function(e) {
+    warning("Failed x2 to fetch commits for: ", repo)
+    data.frame()
+  })
+})
+
+repo_all_commits <- dplyr::bind_rows(repo_all_commits, failed_repo_all_commits)
 
 new_people <- repo_all_commits %>% 
   filter(!is.na(author_login)) %>% 

--- a/scripts/ppnetwork.R
+++ b/scripts/ppnetwork.R
@@ -38,7 +38,7 @@ repo_all_commits <- git_stats |>
 
 new_people <- repo_all_commits %>% 
   filter(!is.na(author_login)) %>% 
-  select(repository, author_login) %>% 
+  select(repository = repo_name, author_login) %>% 
   distinct()
 
 people_info <- new_people %>%


### PR DESCRIPTION
# Pull Request

This PR addresses the issue of website build failure inside a github action.

# Description

As described in the issue, there are 2 repos for which we fail to get commits. I was able to identify the problem by fetching commits in a map loop, rather than trying to fetch everything at once.

By default the code is trying to get all commits since 10 years ago, and for those 2 repos it is the problem. In this PR I've added a fallback to fetch commits from only 1 year ago for those repositories that fail on a 10-year horizon.

## Metadata

Please reference any related issues here (using `#issuenumber`): #426 
People to notify: @rossfarrugia, @mdubel
