### PR TITLE
fix: use the right colname of the get_commits output

### DIFF
--- a/scripts/ppnetwork.R
+++ b/scripts/ppnetwork.R
@@ -64,7 +64,7 @@ repo_all_commits <- dplyr::bind_rows(repo_all_commits, failed_repo_all_commits)
 
 new_people <- repo_all_commits %>% 
   filter(!is.na(author_login)) %>% 
-  select(repository = repo_name, author_login) %>% 
+  select(repository, author_login) %>% 
   distinct()
 
 people_info <- new_people %>%


### PR DESCRIPTION
# Pull Request

Hotfix to use the correct column name of the `get_commits` output.

# Description

Use `repository` column name instead of `repo_name` in the output dataframe of `GitStats::get_commits()` function. The error was introduced by me in the previous PR due to GitStats version mismatch.


## Metadata

Please reference any related issues here (using `#issuenumber`): 
People to notify: @rossfarrugia 
